### PR TITLE
fix(BubbleList): 修复 `complete` 事件在 `only-last` 模式下无法正确触发

### DIFF
--- a/packages/components/src/components/BubbleList/index.vue
+++ b/packages/components/src/components/BubbleList/index.vue
@@ -42,8 +42,12 @@ const showBackToBottom = ref(false) // 控制按钮显示
 /* 计算有效的触发索引数组 */
 const effectiveTriggerIndices = computed(() => {
   if (props.triggerIndices === 'only-last') {
-    const triggerIndices = props.list.filter(item => item.typing).map((_, index) => index)
-    return triggerIndices.length > 0 ? [triggerIndices[triggerIndices.length - 1]] : []
+    for (let i = props.list.length - 1; i >= 0; i--) {
+      if (props.list[i].typing) {
+        return [i]
+      }
+    }
+    return []
   }
   else if (props.triggerIndices === 'all') {
     return props.list.map((_, index) => index)


### PR DESCRIPTION
复现代码如下：

```vue
<script setup>
const bubbleItems = ref([
  {
    key: 1,
    role: 'ai',
    placement: 'start',
    content:
      '这是机器人的消息这是机器人的消息这是机器人的消息这是机器人的消息这是机器人的消息这是机器人的消息这是机器人的消息',
    shape: 'corner',
    variant: 'filled',
    isMarkdown: false,
    avatar: 'https://cube.elemecdn.com/0/88/03b0d39583f48206768a7534e55bcpng.png',
  },
  {
    key: 2,
    role: 'user',
    placement: 'end',
    content: '这是用户的消息',
    shape: 'corner',
    variant: 'outlined',
    isMarkdown: false,
    typing: true,
    avatar: 'https://cube.elemecdn.com/0/88/03b0d39583f48206768a7534e55bcpng.png',
  },
])

function onCompleteFunc() {
  console.log('打字结束')
}
</script>

<template>
  <BubbleList
    :list="bubbleItems"
    @complete="onCompleteFunc"
  />
</template>

```