### PR TITLE
fix: compile warning

### DIFF
--- a/apps/playground/src/components/WelcomeDemo.vue
+++ b/apps/playground/src/components/WelcomeDemo.vue
@@ -64,7 +64,7 @@ import { MoreFilled, Share } from '@element-plus/icons-vue'
   overflow: auto;
 
   .extra-container {
-    :deep {
+    :deep() {
       .el-icon {
         font-size: 18px;
       }


### PR DESCRIPTION
Fix the warning of the playground development environment!
![wechat_2025-05-22_105032_657](https://github.com/user-attachments/assets/5563efcc-8a3f-489a-8b7b-c3204932d795)
