### PR TITLE
refactor(XMarkdownCore): 代码块头部样式及交互优化

### DIFF
--- a/packages/core/src/components/XMarkdownCore/components/CodeBlock/copy-code-button.vue
+++ b/packages/core/src/components/XMarkdownCore/components/CodeBlock/copy-code-button.vue
@@ -22,12 +22,12 @@ function handleClick() {
 
 <template>
   <ElButton
-    class="shiki-header-button markdown-language-header-button"
+    class="shiki-header-button markdown-elxLanguage-header-button"
     @click="handleClick"
   >
     <component
       :is="copied ? Select : CopyDocument"
-      class="markdown-language-header-button-text"
+      class="markdown-elxLanguage-header-button-text"
       :class="[copied && 'copied']"
     />
   </ElButton>

--- a/packages/core/src/components/XMarkdownCore/components/CodeBlock/index.vue
+++ b/packages/core/src/components/XMarkdownCore/components/CodeBlock/index.vue
@@ -220,7 +220,7 @@ watch(
     :style="preStyle"
     @vue:updated="handleUpdated"
   >
-    <div class="markdown-language-header-div is-always-shadow">
+    <div class="markdown-elxLanguage-header-div is-always-shadow">
       <component
         :is="renderSlot('codeHeader')"
         v-if="codeXSlot?.codeHeader && renderSlot('codeHeader')"

--- a/packages/core/src/components/XMarkdownCore/components/CodeBlock/run-code-button.vue
+++ b/packages/core/src/components/XMarkdownCore/components/CodeBlock/run-code-button.vue
@@ -13,7 +13,7 @@ function handleClick() {
 
 <template>
   <ElButton
-    class="shiki-header-button markdown-language-header-button"
+    class="shiki-header-button markdown-elxLanguage-header-button"
     @click="handleClick"
   >
     <View />

--- a/packages/core/src/components/XMarkdownCore/components/CodeBlock/shiki-header.ts
+++ b/packages/core/src/components/XMarkdownCore/components/CodeBlock/shiki-header.ts
@@ -161,7 +161,7 @@ export function languageEle(language: string) {
   return h(
     ElSpace,
     {
-      class: `markdown-language-header-space markdown-language-header-space-start markdown-language-header-span`,
+      class: `markdown-elxLanguage-header-space markdown-elxLanguage-header-space-start markdown-elxLanguage-header-span`,
       direction: 'horizontal',
       onClick: (ev: MouseEvent) => {
         toggleExpand(ev);
@@ -172,7 +172,7 @@ export function languageEle(language: string) {
         h(
           'span',
           {
-            class: 'markdown-language-header-span is-always-shadow'
+            class: 'markdown-elxLanguage-header-span is-always-shadow'
           },
           language || ''
         ),
@@ -185,7 +185,7 @@ export function languageEle(language: string) {
             default: () => [
               h(ArrowDownBold, {
                 class:
-                  'markdown-language-header-toggle markdown-language-header-toggle-expand '
+                  'markdown-elxLanguage-header-toggle markdown-elxLanguage-header-toggle-expand '
               })
             ]
           }
@@ -207,7 +207,7 @@ export function controlEle(copy: () => void) {
   return h(
     ElSpace,
     {
-      class: `markdown-language-header-space`,
+      class: `markdown-elxLanguage-header-space`,
       direction: 'horizontal'
     },
     {
@@ -231,7 +231,7 @@ export function controlHasRunCodeEle(copy: () => void, view: () => void) {
   return h(
     ElSpace,
     {
-      class: `markdown-language-header-space`,
+      class: `markdown-elxLanguage-header-space`,
       direction: 'horizontal'
     },
     {
@@ -255,7 +255,7 @@ export function toggleThemeEle() {
   return h(
     ElButton,
     {
-      class: 'shiki-header-button markdown-language-header-toggle',
+      class: 'shiki-header-button markdown-elxLanguage-header-toggle',
       onClick: () => {
         toggleTheme();
       }
@@ -263,7 +263,7 @@ export function toggleThemeEle() {
     {
       default: () =>
         h(!isDark.value ? Moon : Sunny, {
-          class: 'markdown-language-header-toggle'
+          class: 'markdown-elxLanguage-header-toggle'
         })
     }
   );
@@ -280,7 +280,6 @@ export function toggleThemeEle() {
  * @param elem
  */
 export function expand(elem: HTMLElement) {
-  elem.style.height = 'auto';
   elem.classList.add('is-expanded');
 }
 
@@ -293,7 +292,6 @@ export function expand(elem: HTMLElement) {
  * @param elem
  */
 export function collapse(elem: HTMLElement) {
-  elem.style.height = '42px';
   elem.classList.remove('is-expanded');
 }
 
@@ -370,6 +368,8 @@ export function extractCodeFromHtmlLines(lines: string[]): string {
   return output.join('\n');
 }
 
+let isToggling = false;
+
 /**
  * @description 描述 切换展开状态
  * @date 2025-06-26 21:29:50
@@ -379,10 +379,17 @@ export function extractCodeFromHtmlLines(lines: string[]): string {
  * @param ev
  */
 export function toggleExpand(ev: MouseEvent): { isExpand: boolean } {
+  if (isToggling) return { isExpand: false }; // 防抖保护
+  isToggling = true;
+
   const ele = ev.currentTarget as HTMLElement;
   const preMd = ele.closest('.pre-md') as HTMLElement | null;
 
   if (preMd) {
+    setTimeout(() => {
+      isToggling = false;
+    }, 250);
+
     if (preMd.classList.contains('is-expanded')) {
       collapse(preMd);
       return { isExpand: false };
@@ -391,6 +398,8 @@ export function toggleExpand(ev: MouseEvent): { isExpand: boolean } {
       return { isExpand: true };
     }
   }
+
+  isToggling = false;
   return { isExpand: false };
 }
 

--- a/packages/core/src/components/XMarkdownCore/style/shiki.scss
+++ b/packages/core/src/components/XMarkdownCore/style/shiki.scss
@@ -120,27 +120,13 @@ body.dark .shiki span {
   }
 
   pre div.pre-md {
-    height: 42px;
-    display: flex;
-    flex-direction: column;
-  }
-
-  pre div.is-expanded {
-    height: auto !important;
-    code {
-      padding: 8px;
-      height: auto !important;
-    }
-    .markdown-language-header-toggle-expand {
-      transform: rotate(0deg) !important;
-    }
-  }
-
-  pre div.pre-md {
     position: relative;
     border-radius: var(--shiki-custom-brr-mini);
     border: 1px solid var(--el-border-color);
-    .markdown-language-header-div {
+    min-width: 180px !important;
+    min-height: 42px;
+    .markdown-elxLanguage-header-div {
+      box-sizing: content-box !important;
       position: sticky;
       top: 0;
       display: flex;
@@ -152,14 +138,13 @@ body.dark .shiki span {
       -webkit-backdrop-filter: blur(var(--shiki-custom-blur));
       backdrop-filter: blur(var(--shiki-custom-blur));
       margin: 0;
-      box-sizing: border-box;
       background-color: var(--shiki-code-header-bg);
       span {
         box-shadow: none !important;
         background-color: transparent !important;
       }
 
-      .markdown-language-header-span {
+      .markdown-elxLanguage-header-span {
         font-size: 14px;
         font-family: sans-serif;
         color: var(--shiki-code-header-span-color) !important;
@@ -172,14 +157,14 @@ body.dark .shiki span {
         }
       }
 
-      .markdown-language-header-space-start,
-      .markdown-language-header-space {
+      .markdown-elxLanguage-header-space-start,
+      .markdown-elxLanguage-header-space {
         display: flex;
         justify-content: flex-end;
         align-items: center;
       }
 
-      .markdown-language-header-space-start {
+      .markdown-elxLanguage-header-space-start {
         justify-content: flex-start;
       }
 
@@ -190,7 +175,7 @@ body.dark .shiki span {
         width: fit-content !important;
         padding: 5px 6px;
         opacity: 1;
-        transition: all 0.3s ease-in-out;
+        transition: color 0.3s ease-in-out;
         cursor: pointer;
         .el-icon {
           font-size: 16px;
@@ -200,7 +185,6 @@ body.dark .shiki span {
           background-color: transparent !important;
           color: var(--shiki-code-header-span-color) !important;
         }
-        transition: background-color 0.3s;
         &:hover {
           background-color: var(--shiki-code-header-btn-bg);
           color: var(--el-color-primary) !important;
@@ -224,9 +208,9 @@ body.dark .shiki span {
         }
       }
 
-      .markdown-language-header-toggle-expand {
+      .markdown-elxLanguage-header-toggle-expand {
         margin: 2px 0 0 0;
-        transition: all 0.3s ease-in-out;
+        transition: transform 0.3s ease-in-out;
         transform: rotate(-90deg);
       }
 
@@ -241,6 +225,7 @@ body.dark .shiki span {
       width: 100%;
       height: 0;
       overflow: hidden;
+      padding: 0 !important;
 
       & > span {
         width: max-content;
@@ -283,6 +268,17 @@ body.dark .shiki span {
         -webkit-backdrop-filter: blur(var(--shiki-custom-blur));
         backdrop-filter: blur(var(--shiki-custom-blur));
       }
+    }
+  }
+
+  pre div.is-expanded {
+    height: auto !important;
+    code {
+      padding: 8px !important;
+      height: auto !important;
+    }
+    .markdown-elxLanguage-header-toggle-expand {
+      transform: rotate(0deg) !important;
     }
   }
 }

--- a/packages/core/src/stories/XMarkdown/highlight-code.vue
+++ b/packages/core/src/stories/XMarkdown/highlight-code.vue
@@ -16,7 +16,7 @@ const timer = ref();
 const index = ref(0);
 function start() {
   timer.value = setInterval(() => {
-    index.value += 50;
+    index.value += 25;
     if (index.value > props.markdown.length) {
       clearInterval(timer.value);
       index.value = props.markdown.length;
@@ -54,7 +54,7 @@ const codeXSlotConfig: CodeBlockHeaderFunctionExpose = {
     return h(
       ElSpace,
       {
-        class: `markdown-language-header-space`,
+        class: `markdown-elxLanguage-header-space`,
         direction: 'horizontal'
       },
       {


### PR DESCRIPTION
- 修改代码块头部相关 CSS 类名，避免冲突
- 优化代码块头部的样式，包括颜色、过渡效果等
- 添加防抖保护，避免快速重复展开/收起代码块
- 调整代码块展开/收起的逻辑，移除不必要的高度设置
- 优化复制代码和切换主题按钮的样式