### PR TITLE
refactor(docs): 更新文档配置和路由主要解决docFooter在组件页面匹配导致不能使用

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -41,32 +41,6 @@ export default defineConfig({
     search: {
       provider: 'local',
     },
-    // 定义 footer 内容
-    // footer: {
-    //   message: 'Released under the MIT License.',
-    //   copyright: `Copyright © Element-Plus-X ${new Date().getFullYear()}&nbsp;&nbsp;<a href="https://beian.miit.gov.cn/" target="_blank">赣ICP备2025057058号-1</a> `,
-    // },
-
-    // 中文配置
-    // 文档底部
-    docFooter: {
-      prev: '上一篇',
-      next: '下一篇',
-    },
-    sidebarMenuLabel: '菜单',
-    returnToTopLabel: '返回顶部',
-    lastUpdatedText: '最后更新于',
-    // editLink: {
-    //   pattern: "https://github.com/yunyoujun/chat-ui/edit/main/docs/:path",
-    //   text: "在 GitHub 上编辑此页",
-    // },
-    darkModeSwitchLabel: '深色模式',
-    // lightModeSwitchTitle: '切换到浅色模式',
-    // darkModeSwitchTitle: '切换到深色模式',
-    outline: {
-      label: '📖 目录',
-      level: [2, 6],
-    },
   },
   // markdown 配置
   markdown: {

--- a/apps/docs/.vitepress/locales.mts
+++ b/apps/docs/.vitepress/locales.mts
@@ -45,47 +45,47 @@ const config = {
           {
             text: 'New',
             items: [
-              { text: 'XMarkdown Render 📜', link: '/en/components/xmarkdown' },
+              { text: 'XMarkdown Render 📜', link: '/en/components/xmarkdown/' },
             ],
           },
           {
             text: 'General',
             items: [
-              { text: 'Typewriter ✍', link: '/en/components/typewriter' },
-              { text: 'Bubble 🔥', link: '/en/components/bubble' },
-              { text: 'BubbleList 🍅', link: '/en/components/bubbleList' },
-              { text: 'Conversations 📱', link: '/en/components/conversations' },
+              { text: 'Typewriter ✍', link: '/en/components/typewriter/' },
+              { text: 'Bubble 🔥', link: '/en/components/bubble/' },
+              { text: 'BubbleList 🍅', link: '/en/components/bubbleList/' },
+              { text: 'Conversations 📱', link: '/en/components/conversations/' },
             ],
           },
           {
             text: 'Awakening',
             items: [
-              { text: 'Welcome 🌹', link: '/en/components/welcome' },
-              { text: 'Prompts 🎁', link: '/en/components/prompts' },
+              { text: 'Welcome 🌹', link: '/en/components/welcome/' },
+              { text: 'Prompts 🎁', link: '/en/components/prompts/' },
             ],
           },
           {
             text: 'Expression',
             items: [
-              { text: 'FilesCard 📇', link: '/en/components/filesCard' },
-              { text: 'Attachments 📪️', link: '/en/components/attachments' },
-              { text: 'Sender 💭', link: '/en/components/sender' },
-              { text: 'MentionSender 🦥', link: '/en/components/mentionSender' },
+              { text: 'FilesCard 📇', link: '/en/components/filesCard/' },
+              { text: 'Attachments 📪️', link: '/en/components/attachments/' },
+              { text: 'Sender 💭', link: '/en/components/sender/' },
+              { text: 'MentionSender 🦥', link: '/en/components/mentionSender/' },
             ],
           },
           {
             text: 'Confirmation',
             items: [
-              { text: 'Thinking 🍓', link: '/en/components/thinking' },
-              { text: 'ThoughtChain 🔗', link: '/en/components/thoughtChain' },
+              { text: 'Thinking 🍓', link: '/en/components/thinking/' },
+              { text: 'ThoughtChain 🔗', link: '/en/components/thoughtChain/' },
             ],
           },
           {
             text: 'Tools',
             items: [
-              { text: 'useRecord 🌴', link: '/en/components/useRecord' },
-              { text: 'useXStream 🌱', link: '/en/components/useXStream' },
-              { text: 'useSend & XRequest 🌳', link: '/en/components/useSend' },
+              { text: 'useRecord 🌴', link: '/en/components/useRecord/' },
+              { text: 'useXStream 🌱', link: '/en/components/useXStream/' },
+              { text: 'useSend & XRequest 🌳', link: '/en/components/useSend/' },
             ],
           },
         ],
@@ -175,47 +175,47 @@ const config = {
           {
             text: '上新',
             items: [
-              { text: 'XMarkdown 渲染组件 📜', link: '/zh/components/xmarkdown' },
+              { text: 'XMarkdown 渲染组件 📜', link: '/zh/components/xmarkdown/' },
             ],
           },
           {
             text: '通用',
             items: [
-              { text: 'Typewriter 打字器 ✍', link: '/zh/components/typewriter' },
-              { text: 'Bubble 对话气泡 🔥', link: '/zh/components/bubble' },
-              { text: 'BubbleList 气泡列表 🍅', link: '/zh/components/bubbleList' },
-              { text: 'Conversations 会话管理 📱', link: '/zh/components/conversations' },
+              { text: 'Typewriter 打字器 ✍', link: '/zh/components/typewriter/' },
+              { text: 'Bubble 对话气泡 🔥', link: '/zh/components/bubble/' },
+              { text: 'BubbleList 气泡列表 🍅', link: '/zh/components/bubbleList/' },
+              { text: 'Conversations 会话管理 📱', link: '/zh/components/conversations/' },
             ],
           },
           {
             text: '唤醒',
             items: [
-              { text: 'Welcome 欢迎 🌹', link: '/zh/components/welcome' },
-              { text: 'Prompts 提示集 🎁', link: '/zh/components/prompts' },
+              { text: 'Welcome 欢迎 🌹', link: '/zh/components/welcome/' },
+              { text: 'Prompts 提示集 🎁', link: '/zh/components/prompts/' },
             ],
           },
           {
             text: '表达',
             items: [
-              { text: 'FilesCard 文件卡片 📇', link: '/zh/components/filesCard' },
-              { text: 'Attachments 输入附件 📪️', link: '/zh/components/attachments' },
-              { text: 'Sender 输入框 💭', link: '/zh/components/sender' },
-              { text: 'MentionSender 提及输入框 🦥', link: '/zh/components/mentionSender' },
+              { text: 'FilesCard 文件卡片 📇', link: '/zh/components/filesCard/' },
+              { text: 'Attachments 输入附件 📪️', link: '/zh/components/attachments/' },
+              { text: 'Sender 输入框 💭', link: '/zh/components/sender/' },
+              { text: 'MentionSender 提及输入框 🦥', link: '/zh/components/mentionSender/' },
             ],
           },
           {
             text: '确认',
             items: [
-              { text: 'Thinking 思考中 🍓', link: '/zh/components/thinking' },
-              { text: 'ThoughtChain 思维链 🔗', link: '/zh/components/thoughtChain' },
+              { text: 'Thinking 思考中 🍓', link: '/zh/components/thinking/' },
+              { text: 'ThoughtChain 思维链 🔗', link: '/zh/components/thoughtChain/' },
             ],
           },
           {
             text: '工具',
             items: [
-              { text: 'useRecord 🌴', link: '/zh/components/useRecord' },
-              { text: 'useXStream 🌱', link: '/zh/components/useXStream' },
-              { text: 'useSend & XRequest 🌳', link: '/zh/components/useSend' },
+              { text: 'useRecord 🌴', link: '/zh/components/useRecord/' },
+              { text: 'useXStream 🌱', link: '/zh/components/useXStream/' },
+              { text: 'useSend & XRequest 🌳', link: '/zh/components/useSend/' },
             ],
           },
         ],


### PR DESCRIPTION
- 移除了 config.mts 文件中未使用的 footer 配置
- 修改了 locales.mts 文件中的路由路径，末尾添加斜杠