### PR TITLE
fix(core): 修复shiki主题颜色问题

### DIFF
--- a/packages/core/src/components/XMarkdownCore/shared/constants.ts
+++ b/packages/core/src/components/XMarkdownCore/shared/constants.ts
@@ -30,7 +30,7 @@ export const DEFAULT_PROPS = {
   sanitizeOptions: () => ({}),
   mermaidConfig: () => ({}),
   langs: () => [],
-  defaultThemeMode: 'light' as 'light' | 'dark',
+  defaultThemeMode: '' as 'light' | 'dark',
   themes: () => ({ ...shikiThemeDefault }),
   colorReplacements: () => ({}),
   needViewCodeBtn: true,

--- a/packages/core/src/stories/BubbleList/CustomSolt.vue
+++ b/packages/core/src/stories/BubbleList/CustomSolt.vue
@@ -102,7 +102,7 @@ onMounted(() => {
             :src="item.avatar"
             class="avatar"
             :style="{ width: item.avatarSize, height: item.avatarSize }"
-          />
+          >
         </template>
 
         <template #header="{ item }">
@@ -121,7 +121,6 @@ onMounted(() => {
             <XMarkdown
               v-if="item.role === 'ai'"
               :markdown="item.content ?? ''"
-              default-theme-mode="dark"
             />
             <span v-else>{{ item.content }} </span>
           </div>


### PR DESCRIPTION
修复shiki主题颜色问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default theme behavior for markdown content to no longer force a light theme, allowing it to follow the surrounding/app theme.

* **Documentation**
  * Revised BubbleList example to remove the explicit dark theme on AI content, aligning with the new default theme handling.

* **Style**
  * Minor template cleanup in the avatar image tag within the BubbleList example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->