### PR TITLE
docs: 修复文档示例代码中script标签缺少setup属性

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -67,7 +67,7 @@ yarn install vue-element-plus-x
 1. **On-demand Import**
 
 ```vue
-<script>
+<script setup>
 import { BubbleList, Sender } from 'vue-element-plus-x';
 
 const list = [
@@ -113,13 +113,13 @@ app.mount('#app');
 ## 🌟 Implemented Components and Hooks
 
 | Component Name       | Description                                                                    | Documentation Link                                                          |
-| -------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------- | 
+| -------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
 | `Typewriter`         | Typewriter animation component                                                 | [📄 Documentation](https://element-plus-x.com/en/components/typewriter/)    |
 | `Bubble`             | Extended bubble message component                                              | [📄 Documentation](https://element-plus-x.com/en/components/bubble/)        |
 | `BubbleList`         | Extended bubble message list component                                         | [📄 Documentation](https://element-plus-x.com/en/components/bubbleList/)    |
 | `Conversations`      | Extended conversation management component                                     | [📄 Documentation](https://element-plus-x.com/en/components/conversations/) |
 | `Welcome`            | Welcome component                                                              | [📄 Documentation](https://element-plus-x.com/en/components/welcome/)       |
-| `Prompts`            | Prompt set component                                                           | [📄 Documentation](https://element-plus-x.com/en/components/prompts/)       | 
+| `Prompts`            | Prompt set component                                                           | [📄 Documentation](https://element-plus-x.com/en/components/prompts/)       |
 | `FilesCard`          | File card component                                                            | [📄 Documentation](https://element-plus-x.com/en/components/filesCard/)     |
 | `Attachments`        | File attachment upload component                                               | [📄 Documentation](https://element-plus-x.com/en/components/attachments/)   |
 | `Sender`             | Intelligent input box (with voice interaction and built-in command operations) | [📄 Documentation](https://element-plus-x.com/en/components/sender/)        |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ yarn install vue-element-plus-x
 1. **按需引入**
 
 ```vue
-<script>
+<script setup>
 import { BubbleList, Sender } from 'vue-element-plus-x';
 
 const list = [

--- a/apps/docs/en/introduce.md
+++ b/apps/docs/en/introduce.md
@@ -71,7 +71,7 @@ yarn add vue-element-plus-x --save
 1. **On-demand Import**
 
 ```vue
-<script>
+<script setup>
 import { BubbleList, Sender } from 'vue-element-plus-x';
 
 const list = [
@@ -112,7 +112,6 @@ app.mount('#app');
 <!-- This method is still under testing -->
 <!-- CDN Import -->
 <script src="https://unpkg.com/vue-element-plus-x@1.3.0/dist/umd/index.js"></script>
-
 ```
 
 ## 🌟 Implemented Components and Hooks

--- a/apps/docs/zh/introduce.md
+++ b/apps/docs/zh/introduce.md
@@ -71,7 +71,7 @@ yarn add vue-element-plus-x --save
 1. **按需引入**
 
 ```vue
-<script>
+<script setup>
 import { BubbleList, Sender } from 'vue-element-plus-x';
 
 const list = [
@@ -112,7 +112,6 @@ app.mount('#app');
 <!-- 该方法 有待测试 -->
 <!-- CDN 引入 -->
 <script src="https://unpkg.com/vue-element-plus-x@1.3.0/dist/umd/index.js"></script>
-
 ```
 
 ## 🌟 已实现 组件 和 Hooks

--- a/packages/core/README.en.md
+++ b/packages/core/README.en.md
@@ -68,7 +68,7 @@ yarn install vue-element-plus-x
 1. **On-demand Import**
 
 ```vue
-<script>
+<script setup>
 import { BubbleList, Sender } from 'vue-element-plus-x';
 
 const list = [
@@ -109,7 +109,6 @@ app.mount('#app');
 <!-- This method is still under testing -->
 <!-- CDN Import -->
 <script src="https://unpkg.com/vue-element-plus-x@1.3.0/dist/umd/index.js"></script>
-
 ```
 
 ## 🌟 Implemented Components and Hooks

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -67,7 +67,7 @@ yarn install vue-element-plus-x
 1. **按需引入**
 
 ```vue
-<script>
+<script setup>
 import { BubbleList, Sender } from 'vue-element-plus-x';
 
 const list = [
@@ -108,7 +108,6 @@ app.mount('#app');
 <!-- 该方法 有待测试 -->
 <!-- CDN 引入 -->
 <script src="https://unpkg.com/vue-element-plus-x@1.3.0/dist/umd/index.js"></script>
-
 ```
 
 ## 🌟 已实现 组件 和 Hooks


### PR DESCRIPTION
修复文档示例代码中script标签缺少setup属性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vue component usage examples to demonstrate `<script setup>` syntax (Vue 3 Composition API) across all documentation files.
  * Improved code example formatting by removing extraneous whitespace.
  * Adjusted component table layout for better alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->