### PR TITLE
feat(Thinking): 新增cancel状态标识思考已取消

### DIFF
--- a/packages/core/src/components/Thinking/index.vue
+++ b/packages/core/src/components/Thinking/index.vue
@@ -40,8 +40,7 @@ watch(
 
 // 处理展开/收起
 function changeExpand() {
-  if (props.disabled)
-    return;
+  if (props.disabled) return;
   isExpanded.value = !isExpanded.value;
   emit('change', { value: isExpanded.value, status: props.status });
   emit('update:modelValue', isExpanded.value);
@@ -102,6 +101,13 @@ watch(
           <el-icon v-if="status === 'error'" class="el-icon-center error-color">
             <CircleCloseFilled />
           </el-icon>
+
+          <el-icon
+            v-if="status === 'cancel'"
+            class="el-icon-center cancel-color"
+          >
+            <CircleCloseFilled />
+          </el-icon>
         </slot>
       </span>
 
@@ -114,7 +120,9 @@ watch(
                 ? '思考遇到问题'
                 : status === 'end'
                   ? '思考完成'
-                  : '开始思考'
+                  : status === 'cancel'
+                    ? '中断思考'
+                    : '开始思考'
           }}
         </slot>
       </span>

--- a/packages/core/src/components/Thinking/style.scss
+++ b/packages/core/src/components/Thinking/style.scss
@@ -42,6 +42,11 @@
   .error-color {
     color: var(--el-color-danger);
   }
+
+  /* 手动打断颜色 */
+  .cancel-color {
+    color: var(--el-color-info);
+  }
 }
 
 .trigger:hover {

--- a/packages/core/src/components/Thinking/types.d.ts
+++ b/packages/core/src/components/Thinking/types.d.ts
@@ -1,5 +1,5 @@
 // 定义组件状态类型
-export type ThinkingStatus = 'start' | 'thinking' | 'end' | 'error';
+export type ThinkingStatus = 'start' | 'thinking' | 'end' | 'error' | 'cancel';
 
 // 定义组件 ThinkingProps
 export interface ThinkingProps {


### PR DESCRIPTION
为Thinking组件新增cancel状态，用于标识思考流程被主动中断的场景，完善组件状态体系。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for canceling thinking operations during processing with dedicated visual feedback
  * New cancel status includes custom styling and status indicators to distinguish interrupted operations from other states

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->