### PR TITLE
ci(docs): pass github token to docs workflows

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -96,6 +96,8 @@ jobs:
           DOCS_V2_ORIGIN: https://v2.element-plus-x.com
           DOCS_ROOT_ORIGIN: https://element-plus-x.com
           DOCS_USE_SOURCE: 'true'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm run build:docs
 
       - name: Setup SSH

--- a/.github/workflows/docs-deploy-verify.yaml
+++ b/.github/workflows/docs-deploy-verify.yaml
@@ -67,6 +67,8 @@ jobs:
           DOCS_V2_ORIGIN: https://v2.element-plus-x.com
           DOCS_ROOT_ORIGIN: https://element-plus-x.com
           DOCS_USE_SOURCE: 'true'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm run build:docs
 
       - name: Resolve verify path


### PR DESCRIPTION
## Summary
- pass `GITHUB_TOKEN` and `GH_TOKEN` into docs build steps
- avoid GitHub API rate limits during contributor/changelog generation in docs workflows
- keep release and verify deployment behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation deployment workflows with environment variable configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->